### PR TITLE
Fix display resolution detection to report native instead of scaled resolution plus debug logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -1437,17 +1437,48 @@ ipcMain.handle('get-displays', async () => {
   const displays = screen.getAllDisplays();
   const primaryDisplay = screen.getPrimaryDisplay();
 
+  console.log('===== DEBUG: Display Detection =====');
+  displays.forEach((display, index) => {
+    console.log(`Display ${index}:`, {
+      id: display.id,
+      'bounds.width': display.bounds.width,
+      'bounds.height': display.bounds.height,
+      'size.width': display.size.width,
+      'size.height': display.size.height,
+      scaleFactor: display.scaleFactor,
+      isPrimary: display.id === primaryDisplay.id
+    });
+  });
+
   // Format display information for the UI
-  return displays.map(display => ({
-    id: display.id,
-    bounds: display.bounds,
-    workArea: display.workArea,
-    size: display.size,
-    scaleFactor: display.scaleFactor,
-    rotation: display.rotation,
-    isPrimary: display.id === primaryDisplay.id,
-    label: `Display ${display.id === primaryDisplay.id ? '(Primary)' : ''} - ${display.size.width}x${display.size.height}`
-  }));
+  const result = displays.map(display => {
+    // On Windows, bounds already contains scaled resolution
+    // To get native/physical resolution: bounds × scaleFactor
+    const nativeWidth = Math.round(display.bounds.width * display.scaleFactor);
+    const nativeHeight = Math.round(display.bounds.height * display.scaleFactor);
+    
+    return {
+      id: display.id,
+      bounds: display.bounds,
+      workArea: display.workArea,
+      // Native/physical resolution (actual monitor pixels)
+      width: nativeWidth,
+      height: nativeHeight,
+      // Logical/scaled resolution (OS scaled)
+      logicalWidth: display.size.width,
+      logicalHeight: display.size.height,
+      scaleFactor: display.scaleFactor,
+      rotation: display.rotation,
+      isPrimary: display.id === primaryDisplay.id,
+      label: `Display ${display.id === primaryDisplay.id ? '(Primary)' : ''} - ${nativeWidth}x${nativeHeight}`
+    };
+  });
+
+  console.log('===== DEBUG: Returning to frontend =====');
+  console.log(JSON.stringify(result, null, 2));
+  console.log('=====================================');
+
+  return result;
 });
 
 // Get display by ID

--- a/settings-new.js
+++ b/settings-new.js
@@ -462,15 +462,20 @@ class NewSettingsManager {
         }
 
         // Resolution settings
-        if (settings.resolution) {
-            const resSelect = document.getElementById('resolution-select-capture');
+        const resSelect = document.getElementById('resolution-select-capture');
+        if (settings.resolution && settings.resolution.preset) {
             if (settings.resolution.preset === 'custom') {
                 resSelect.value = 'custom';
                 document.getElementById('custom-resolution-container-capture').style.display = 'block';
                 document.getElementById('width-input-capture').value = settings.resolution.width;
                 document.getElementById('height-input-capture').value = settings.resolution.height;
-            } else if (settings.resolution.preset) {
+            } else {
                 resSelect.value = settings.resolution.preset;
+            }
+        } else {
+            // Default to native resolution if no setting exists or preset is empty
+            if (resSelect) {
+                resSelect.value = 'native';
             }
         }
 
@@ -575,13 +580,21 @@ class NewSettingsManager {
 
             if (!select) return;
 
+            console.log('===== DEBUG: Frontend Received Displays =====');
+            console.log(JSON.stringify(displays, null, 2));
+
             select.innerHTML = '';
 
             displays.forEach((display, index) => {
                 const option = document.createElement('option');
-                // Check for bounds property which Electron uses
-                const width = display.bounds?.width || display.size?.width || display.width;
-                const height = display.bounds?.height || display.size?.height || display.height;
+                // Use the pre-calculated native resolution from backend
+                const width = display.width;
+                const height = display.height;
+
+                console.log(`Display ${index} - Using width: ${width}, height: ${height}`);
+                console.log(`  - display.width: ${display.width}`);
+                console.log(`  - display.logicalWidth: ${display.logicalWidth}`);
+                console.log(`  - scaleFactor: ${display.scaleFactor}`);
 
                 option.value = display.id;
                 option.textContent = `Display ${index + 1} - ${width}×${height}`;
@@ -589,6 +602,8 @@ class NewSettingsManager {
                 option.dataset.height = height;
                 select.appendChild(option);
             });
+
+            console.log('=============================================');
 
             // Add custom option
             const customOption = document.createElement('option');


### PR DESCRIPTION
Fix (only) display resolution detection to report native instead of scaled resolution.

Changes:
- main.js: Calculate native/physical resolution by multiplying bounds by scaleFactor (e.g., 3072x1728 at 125% scale = 3840x2160 native)
- settings-new.js: Use pre-calculated display.width/height directly instead of falling back to bounds which contains scaled values
- settings-new.js: Add default value "native" for resolution dropdown when no preset is configured

This fixes the issue where Windows display scaling caused the app to show logical (scaled) resolutions instead of the monitor's native resolution in the Game Resolution dropdown.